### PR TITLE
Updating Tableau Desktop DOWNLOAD_URL

### DIFF
--- a/Tableau/Tableau.download.recipe
+++ b/Tableau/Tableau.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>TableauDesktop</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://downloads.tableau.com/tssoftware/TableauDesktop.dmg</string>
+        <string>http://www.tableau.com/downloads/desktop/mac</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>


### PR DESCRIPTION
The old URL was no longer being updated.