### PR TITLE
Adding Override-able Optional Installer Choices

### DIFF
--- a/Tableau/Tableau.munki.recipe
+++ b/Tableau/Tableau.munki.recipe
@@ -12,6 +12,10 @@
 		<string>apps/Tableau</string>
 		<key>NAME</key>
 		<string>TableauDesktop</string>
+		<key>pkg_ids_set_optional_true</key>
+		<array>
+			<string>com.tableausoftware.desktopShortcut</string>
+		</array>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -22,6 +26,73 @@
 			<string>Tableau Desktop is data visualization software that lets you see and understand data in minutes.</string>
 			<key>display_name</key>
 			<string>Tableau Desktop</string>
+			<key>installer_choices_xml</key>
+			<array>
+				<dict>
+					<key>attributeSetting</key>
+					<integer>1</integer>
+					<key>choiceAttribute</key>
+					<string>selected</string>
+					<key>choiceIdentifier</key>
+					<string>com.tableausoftware.desktop.app</string>
+				</dict>
+				<dict>
+					<key>attributeSetting</key>
+					<integer>0</integer>
+					<key>choiceAttribute</key>
+					<string>selected</string>
+					<key>choiceIdentifier</key>
+					<string>com.tableausoftware.desktopShortcut</string>
+				</dict>
+				<dict>
+					<key>attributeSetting</key>
+					<integer>1</integer>
+					<key>choiceAttribute</key>
+					<string>selected</string>
+					<key>choiceIdentifier</key>
+					<string>com.amazon.redshiftodbc</string>
+				</dict>
+				<dict>
+					<key>attributeSetting</key>
+					<integer>1</integer>
+					<key>choiceAttribute</key>
+					<string>selected</string>
+					<key>choiceIdentifier</key>
+					<string>com.tableausoftware.mysql</string>
+				</dict>
+				<dict>
+					<key>attributeSetting</key>
+					<integer>1</integer>
+					<key>choiceAttribute</key>
+					<string>selected</string>
+					<key>choiceIdentifier</key>
+					<string>com.tableausoftware.oracle</string>
+				</dict>
+				<dict>
+					<key>attributeSetting</key>
+					<integer>1</integer>
+					<key>choiceAttribute</key>
+					<string>selected</string>
+					<key>choiceIdentifier</key>
+					<string>com.tableausoftware.postgresql</string>
+				</dict>
+				<dict>
+					<key>attributeSetting</key>
+					<integer>1</integer>
+					<key>choiceAttribute</key>
+					<string>selected</string>
+					<key>choiceIdentifier</key>
+					<string>com.simba.sparkodbc</string>
+				</dict>
+				<dict>
+					<key>attributeSetting</key>
+					<integer>1</integer>
+					<key>choiceAttribute</key>
+					<string>selected</string>
+					<key>choiceIdentifier</key>
+					<string>com.simba.sqlserverodbc</string>
+				</dict>
+			</array>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -96,6 +167,10 @@
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
 		</dict>
 	</array>
 </dict>

--- a/Tableau/Tableau.munki.recipe
+++ b/Tableau/Tableau.munki.recipe
@@ -18,6 +18,10 @@
 		</array>
 		<key>pkginfo</key>
 		<dict>
+			<key>blocking_applications</key>
+			<array>
+				<string>Tableau</string>
+			</array>
 			<key>catalogs</key>
 			<array>
 				<string>testing</string>


### PR DESCRIPTION
Adding the option to override the various Tableau-included database
driver packages.  The override would need to set the desired “selected”
state of the packages in “installer_choices_xml” and add those packages
to “pkg_ids_set_optional”.

Note this creates a dependency on Sam Keeley’s
“MunkiPkginfoReceiptsEditor”.