### PR TITLE
Fixing Version Detection

### DIFF
--- a/Tableau/Tableau.munki.recipe
+++ b/Tableau/Tableau.munki.recipe
@@ -138,8 +138,17 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/payload/Tableau*.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>info_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload/Tableau.app/Contents/Info.plist</string>
+				<string>%found_filename%/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Tableau Desktop’s application name now includes the name of the program.