### PR TITLE
Mirror changes from munki.recipe to pkg.recipe

### DIFF
--- a/Tableau/Tableau.pkg.recipe
+++ b/Tableau/Tableau.pkg.recipe
@@ -46,8 +46,17 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/payload/Tableau*.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>info_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload/Tableau.app/Contents/Info.plist</string>
+				<string>%found_filename%/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Fixes issue with downstream .jss recipes, where the pkg recipe can’t find the version info, since the app name changed. 