### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/NBICreator/NBICreator.download.recipe
+++ b/NBICreator/NBICreator.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/NBICreator.app</string>
 				<key>requirement</key>
 				<string>identifier "com.github.NBICreator" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "Y7QFC8672N")</string> 
 			</dict>

--- a/NBICreator/NBICreator.install.recipe
+++ b/NBICreator/NBICreator.install.recipe
@@ -52,7 +52,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>NBICreator.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/NBICreator/NBICreator.pkg.recipe
+++ b/NBICreator/NBICreator.pkg.recipe
@@ -36,7 +36,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/NBICreator.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Remotix/Remotix.download.recipe
+++ b/Remotix/Remotix.download.recipe
@@ -53,7 +53,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Remotix.app</string>
 				<key>requirement</key>
 				<string>identifier "com.nulana.remotixmacwild" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "K293Y6CVN4"</string> 
 			</dict>

--- a/cTiVo/cTiVo.download.recipe
+++ b/cTiVo/cTiVo.download.recipe
@@ -53,7 +53,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/cTiVo.app</string>
 				<key>requirement</key>
 				<string>identifier "com.cTiVo.cTiVo" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "E8XXXD4S77"</string> 
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.