### PR TITLE
Tableau Desktop.pkg.recipe: Fix plistreader path

### DIFF
--- a/Tableau/Tableau.pkg.recipe
+++ b/Tableau/Tableau.pkg.recipe
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload/Tableau.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
The plistreader section of the recipe expected Tableau.app, but what was really there was Tableau 2020.3.app, causing an error when running the recipe. This would be a problem in the future as Tableau changes versions, so I changed the path to lead to the folder instead of directly to the plist. Plistreader is able to search through bundles in directories automatically so this shouldn't be a problem.

Let me know if you have any feedback. Thanks for all your work on these recipes!