### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/TileMill/TileMill.pkg.recipe
+++ b/TileMill/TileMill.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.gmarnin.pkg.tilemill</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.mapbox.tilemill</string>
 		<key>NAME</key>
 		<string>TileMill</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ❌ TileMill/TileMill.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/gmarnin-recipes/TileMill/TileMill.pkg.recipe
Processing repos/gmarnin-recipes/TileMill/TileMill.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': "(http:\\/\\/.*TileMill-[0-9\\.]+zip)'>macOS",
           'url': 'https://tilemill-project.github.io/tilemill/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
Receipt written to ~/Library/AutoPkg/Cache/com.github.gmarnin.pkg.tilemill/receipts/TileMill.pkg-receipt-20210213-225229.plist

The following recipes failed:
    repos/gmarnin-recipes/TileMill/TileMill.pkg.recipe
        Error in com.github.gmarnin.pkg.tilemill: Processor: URLTextSearcher: Error: No match found on URL: https://tilemill-project.github.io/tilemill/

Nothing downloaded, packaged or imported.
```

