### PR TITLE
Switch to core processor

### DIFF
--- a/Tableau/Tableau.munki.recipe
+++ b/Tableau/Tableau.munki.recipe
@@ -183,7 +183,7 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
+			<string>MunkiOptionalReceiptEditor</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
MunkiPkginfoReceiptsEditor is now a core processor (MunkiOptionalReceiptEditor). It looks like it's a drop-in replacement, as I was able to swap this out and the recipe started working again in AutoPkg 2.7. Thanks!

This should close #20 