### PR TITLE
Cleanup temp app bundle and DMG for Tableau recipes

### DIFF
--- a/Tableau/Tableau.munki.recipe
+++ b/Tableau/Tableau.munki.recipe
@@ -206,20 +206,32 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
             <key>Processor</key>
             <string>MunkiImporter</string>
         </dict>
-    <dict>
-      <!-- If nothing was imported then no need to run the Receipt Editor processor -->
-      <key>Arguments</key>
-      <dict>
-        <key>predicate</key>
-        <string>munki_repo_changed == False</string>
-      </dict>
-      <key>Processor</key>
-      <string>StopProcessingIf</string>
-    </dict>
-    <dict>
-      <key>Processor</key>
-      <string>MunkiOptionalReceiptEditor</string>
-    </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+        </dict>
+        <dict>
+            <!-- If nothing was imported then no need to run the Receipt Editor processor -->
+            <key>Arguments</key>
+            <dict>
+                <key>predicate</key>
+                <string>munki_repo_changed == False</string>
+            </dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiOptionalReceiptEditor</string>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/Tableau/Tableau.pkg.recipe
+++ b/Tableau/Tableau.pkg.recipe
@@ -68,6 +68,18 @@
 			<key>Processor</key>
 			<string>PkgCopier</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/payload</string>
+					<string>%RECIPE_CACHE_DIR%/unpack</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Hi there 👋

The **Tableau** recipes leave residual app bundles + DMGs around, so this PR attempts to cleanup files that are no longer required.

Should save approximately **3GB** of disk space per recipe!

I also fixed the whitespace indentation in the Munki recipe :sparkles: