### PR TITLE
Update MicrosoftCopilot.munki.recipe

### DIFF
--- a/MicrosoftCopilot/MicrosoftCopilot.munki.recipe
+++ b/MicrosoftCopilot/MicrosoftCopilot.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Microsoft Copilot and imports it into Munki.</string>
+    <string>Downloads the latest version of Microsoft Copilot and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.gmarnin.munki.microsoftcopilot</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>NAME</key>
@@ -33,17 +37,62 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.1</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.rtrouton.download.microsoftcopilot</string>
     <key>Process</key>
     <array>
         <dict>
-             <key>Arguments</key>
-             <dict>
-                <key>additional_pkginfo</key>
-              <dict/>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
             </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/Microsoft_365_Copilot_App*.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications</string>
+                <key>pkg_payload_path</key>
+                <string>%found_filename%/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Microsoft 365 Copilot.app</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>MunkiPkginfoMerger</string>
         </dict>
@@ -57,6 +106,18 @@
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Hi, @gmarnin 

This PR adds in steps to create an Installs Array with `derive_minimum_os_version` and tidy up after. 

Output from a successful -v run 
```
 autopkg run -v MicrosoftCopilot.munki.recipe
Looking for com.github.rtrouton.download.microsoftcopilot...
Did not find com.github.rtrouton.download.microsoftcopilot in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.rtrouton.download.microsoftcopilot...
Found com.github.rtrouton.download.microsoftcopilot in recipe map
**load_recipe time: 0.01154004200361669
Processing MicrosoftCopilot.munki.recipe...
WARNING: MicrosoftCopilot.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gmarnin.munki.microsoftcopilot/downloads/Microsoft_Copilot.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Microsoft_Copilot.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-08-06 19:31:12 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Microsoft Corporation (UBF8T346G9)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            64 5D 86 D2 DF 76 9E D7 04 CF B1 FA 1B 38 7F 78 69 DC 87 12 AB 4E 
CodeSignatureVerifier:            0F BC EB BC 29 64 D3 E9 A9 48
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gmarnin.munki.microsoftcopilot/downloads/Microsoft_Copilot.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gmarnin.munki.microsoftcopilot/unpacked
FileFinder
FileFinder: Found file match: '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.gmarnin.munki.microsoftcopilot/unpacked/Microsoft_365_Copilot_App_1.2508.0601.pkg' from globbed '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.gmarnin.munki.microsoftcopilot/unpacked/Microsoft_365_Copilot_App*.pkg'
FileFinder: Basename match: 'Microsoft_365_Copilot_App_1.2508.0601.pkg'
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gmarnin.munki.microsoftcopilot/unpacked/Microsoft_365_Copilot_App_1.2508.0601.pkg/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gmarnin.munki.microsoftcopilot/Applications
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Microsoft 365 Copilot.app
MunkiInstallsItemsCreator: Derived minimum os version as: 14.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.microsoft.m365copilot', 'CFBundleName': 'Microsoft 365 Copilot', 'CFBundleShortVersionString': '1.2508', 'CFBundleVersion': '1.2508.0601', 'minosversion': '14.0', 'path': '/Applications/Microsoft 365 Copilot.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '14.0'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Copilot/Copilot-1.2508.0601__2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Copilot/Microsoft_Copilot-1.2508.0601__2.pkg
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gmarnin.munki.microsoftcopilot/Applications
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gmarnin.munki.microsoftcopilot/unpacked
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gmarnin.munki.microsoftcopilot/receipts/MicrosoftCopilot.munki-receipt-20250812-184621.plist

The following new items were imported into Munki:
    Name     Version      Catalogs  Pkginfo Path                               Pkg Repo Path                                      Icon Repo Path  
    ----     -------      --------  ------------                               -------------                                      --------------  
    Copilot  1.2508.0601  testing   apps/Copilot/Copilot-1.2508.0601__2.plist  apps/Copilot/Microsoft_Copilot-1.2508.0601__2.pkg
```
