### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Logitech/LogitechControlCenter.download.recipe
+++ b/Logitech/LogitechControlCenter.download.recipe
@@ -39,6 +39,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -47,10 +51,6 @@
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/LCC</string>
             </dict>
-        </dict>
-                <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
 			<key>Processor</key>
@@ -73,7 +73,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/LCC Installer.app</string>
 				<key>requirement</key>
-				<string>identifier "com.Logitech.Control Center.Update" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "QED4VVPZWA"</string> 
+				<string>identifier "com.Logitech.Control Center.Update" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "QED4VVPZWA"</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.